### PR TITLE
update from upstream

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/vscode/devcontainers/rust:1-bullseye@sha256:7eb80e1054ba35dd4865e1fb9d9c27f7401b6ba6e406d7fc986e9f7ff9507741
+FROM mcr.microsoft.com/devcontainers/rust:0-1-bullseye@sha256:7eb80e1054ba35dd4865e1fb9d9c27f7401b6ba6e406d7fc986e9f7ff9507741
 
 # [Optional] Uncomment this section to install additional packages.
 # RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,20 +1,20 @@
-// For format details, see https://aka.ms/vscode-remote/devcontainer.json or this file's README at:
-// https://github.com/microsoft/vscode-dev-containers/tree/v0.195.0/containers/rust
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/rust
 {
     "name": "Rust",
+    // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+    // "image": "mcr.microsoft.com/devcontainers/rust:0-1-bullseye",
+
     "build": {
         "dockerfile": "Dockerfile",
         "args": {
             // Use the VARIANT arg to pick a Debian OS version: buster, bullseye
             // Use bullseye when on local on arm64/Apple Silicon.
-            "VARIANT": "bullseye"
+            // We use full sha256
+            // "VARIANT": "bullseye"
         }
     },
-    "runArgs": [
-        "--cap-add=SYS_PTRACE",
-        "--security-opt",
-        "seccomp=unconfined"
-    ],
+    "runArgs": ["--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined"],
     // Configure tool-specific properties.
     "customizations": {
         // Configure properties specific to VS Code.
@@ -25,8 +25,10 @@
                 // VS Code don't watch files under ./target
                 "files.watcherExclude": {
                     "**/target/**": true
-                }
+                },
+                "rust-analyzer.checkOnSave.command": "clippy"
             },
+
             // Add the IDs of extensions you want installed when the container is created.
             "extensions": [
                 "vadimcn.vscode-lldb",
@@ -37,10 +39,25 @@
             ]
         }
     },
+
+    // Use 'mounts' to make the cargo cache persistent in a Docker Volume.
+    // "mounts": [
+    // 	{
+    // 		"source": "devcontainer-cargo-cache-${devcontainerId}",
+    // 		"target": "/usr/local/cargo",
+    // 		"type": "volume"
+    // 	}
+    // ]
+
+    // Features to add to the dev container. More info: https://containers.dev/features.
+    // "features": {},
+
     // Use 'forwardPorts' to make a list of ports inside the container available locally.
     // "forwardPorts": [],
+
     // Use 'postCreateCommand' to run commands after the container is created.
     // "postCreateCommand": "rustc --version",
-    // Comment out to run as root instead.
+
+    // Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
     "remoteUser": "vscode"
 }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,14 +18,35 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
+  BUILD_DOCKER_CONTAINER: false
+  # Use docker.io for Docker Hub if empty
+  REGISTRY: ghcr.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
+  # just a name, but storing it separately as we're nice people
+  DOCKER_IMAGE_ARTIFACT_NAME: Docker image
+  DOCKER_IMAGE_OUTPUT_LOCATION: /tmp
+  DOCKER_IMAGE_TAR_LOCATION: /tmp/docker-image.tar # notice /tmp same as DOCKER_IMAGE_OUTPUT_LOCATION
 
 concurrency:
   # each new commit to a PR runs this workflow
-  # so we need to avoid a long running older one from overwriting the 'pr-<number>-latest'
+  # so we need to avoid a long running older one from overwriting the "pr-<number>-latest"
   group: "${{ github.workflow }} @ ${{ github.ref_name }}"
   cancel-in-progress: true
 
 jobs:
+  produce-docker-container:
+    name: Should Docker container be built?
+    runs-on: ubuntu-latest
+    outputs:
+      should: ${{ fromJSON(env.BUILD_DOCKER_CONTAINER) }}
+
+    steps:
+      - name: Dummy
+        shell: bash
+        run: |
+          echo "These are not the steps you're looking for..."
+
   changes:
     name: Detect changes
     runs-on: ubuntu-latest
@@ -42,13 +63,92 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           filters: .github/file-filters.yml
 
+  calculate-version:
+    name: Calculate version
+    runs-on: ubuntu-latest
+    needs:
+      - changes
+      - produce-docker-container
+    outputs:
+      version: ${{ steps.version.outputs.nextversion }}
+    if: |
+      github.event_name == 'pull_request' &&
+      fromJSON(needs.produce-docker-container.outputs.should) == true &&
+      fromJSON(needs.changes.outputs.code) == true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        with:
+          fetch-depth: 0
+
+      - name: Cache dependencies
+        uses: actions/cache@69d9d449aced6a2ede0bc19182fadc3a0a42d2b0 # v3.2.6
+        env:
+          CACHE_NAME: cargo-cache-dependencies
+        with:
+          path: |
+            ~/.cargo
+            ./target
+          key: ${{ runner.os }}-build-${{ env.CACHE_NAME }}-${{ hashFiles('Cargo.lock') }}-cocogitto
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.CACHE_NAME }}-${{ hashFiles('Cargo.lock') }}-
+            ${{ runner.os }}-build-${{ env.CACHE_NAME }}-
+
+      - name: Set up toolchain
+        shell: bash
+        run: |
+          rm ${HOME}/.cargo/bin/rustfmt
+          rm ${HOME}/.cargo/bin/cargo-fmt
+          rustup update
+
+          cargo --version
+
+      - name: Get binstall
+        shell: bash
+        run: |
+          cd /tmp
+          archive="cargo-binstall-x86_64-unknown-linux-musl.tgz"
+          wget "https://github.com/cargo-bins/cargo-binstall/releases/latest/download/${archive}"
+
+          tar -xvf "./${archive}"
+
+          rm "./${archive}"
+
+          mv ./cargo-binstall ~/.cargo/bin/
+
+      - name: Install cocogitto to get the next version number
+        shell: bash
+        run: |
+          cargo binstall --no-confirm cocogitto --target x86_64-unknown-linux-musl --pkg-url "{ repo }/releases/download/{ version }/{ name }-{ version }-{ target }.tar.gz" --bin-dir "{ bin }" --pkg-fmt tgz
+
+      - name: Calculate next version
+        id: version
+        shell: bash
+        run: |
+          VERSION="$(cog bump --auto --dry-run || true)"
+
+          if [[ -z $VERSION ]]; then
+              VERSION="$(git tag --points-at "$(git rev-list --tags --max-count=1)" | sort --reverse | head --lines 1)"
+
+              echo "No version generated, defaulting to latest git tag: ${VERSION}"
+          else
+              echo "New version: ${VERSION}"
+          fi
+
+          # remove v
+          VERSION="${VERSION//v/}"
+
+          # store
+          echo "nextversion=${VERSION}" >> ${GITHUB_OUTPUT}
+
   cargo-build:
     name: Cargo build
     runs-on: ubuntu-latest
     needs:
       - changes
     if: |
-      (github.event_name == 'pull_request' && needs.changes.outputs.code == 'true')
+      github.event_name == 'pull_request' &&
+      fromJSON(needs.changes.outputs.code) == true
     steps:
       - name: Checkout
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
@@ -86,7 +186,8 @@ jobs:
     needs:
       - changes
     if: |
-      (github.event_name == 'pull_request' && needs.changes.outputs.code == 'true')
+      github.event_name == 'pull_request' &&
+      fromJSON(needs.changes.outputs.code) == true
     steps:
       - name: Checkout
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
@@ -123,8 +224,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - changes
-    if: |
-      (needs.changes.outputs.code == 'true')
+    if: fromJSON(needs.changes.outputs.code) == true
     steps:
       - name: Checkout
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
@@ -205,7 +305,7 @@ jobs:
       - name: Run grcov
         shell: bash
         run: |
-          grcov $(find profiling -name "profile-*.profraw" -print) --source-dir . --binary-path ./target/debug/ --output-type lcov --branch --ignore-not-existing --llvm --keep-only 'src/**' --keep-only 'tests/**' --output-path ./reports/lcov.info
+          grcov $(find profiling -name "profile-*.profraw" -print) --source-dir . --binary-path ./target/debug/ --output-type lcov --branch --ignore-not-existing --llvm --keep-only "src/**" --keep-only "tests/**" --output-path ./reports/lcov.info
 
       - name: Upload to CodeCov
         uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70 # tag=v3.1.1
@@ -231,7 +331,8 @@ jobs:
     needs:
       - changes
     if: |
-      (github.event_name == 'pull_request' && needs.changes.outputs.code == 'true')
+      github.event_name == 'pull_request' &&
+      fromJSON(needs.changes.outputs.code) == true
     steps:
       - name: Checkout
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
@@ -263,6 +364,108 @@ jobs:
         with:
           args: --workspace --all-targets --all-features -- --deny clippy::all --deny clippy::pedantic --deny clippy::cargo
 
+  docker-build:
+    name: Build Docker container
+    runs-on: ubuntu-latest
+    needs:
+      - calculate-version
+    # if: ... is not needed because calculate-version will not run if we disable building the docker container
+    steps:
+      - name: Checkout
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+
+      - name: Set the Cargo.toml version before we copy in the data into the Docker container
+        shell: bash
+        run: |
+          ./.github/scripts/update-version.sh ${{ needs.calculate-version.outputs.version }}
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@f03ac48505955848960e80bbb68046aa35c7b9e7 # v2.4.1
+
+      # TODO validate no changes between github.event.pull_request.head.sha and the actual current sha (representing the hypothetical merge)
+
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@507c2f2dc502c992ad446e3d7a5dfbe311567a96 # v4.3.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=pr,suffix=-latest
+            type=raw,value=pr-${{ github.event.pull_request.base.sha }}-${{ github.event.pull_request.head.sha }}
+          labels: |
+            org.opencontainers.image.version=pr-${{ github.event.number }}
+            org.opencontainers.image.source=${{ github.event.pull_request.html_url }}
+
+      - name: Log into registry ${{ env.REGISTRY }}
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # tag=v2.1.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Lowercase the image name
+        shell: bash
+        run: |
+          echo "IMAGE_NAME=${IMAGE_NAME,,}" >> ${GITHUB_ENV}
+
+      - name: Build Docker image
+        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671 # v4.0.0
+        with:
+          context: .
+          # this container is THE PR's artifact, and we will re-tag it
+          # once the PR has been accepted
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache,mode=max
+          outputs: type=docker,dest=${{ env.DOCKER_IMAGE_TAR_LOCATION }}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        with:
+          name: ${{ env.DOCKER_IMAGE_ARTIFACT_NAME }}
+          path: ${{ env.DOCKER_IMAGE_TAR_LOCATION }}
+
+  docker-publish:
+    name: Publish Docker container
+    runs-on: ubuntu-latest
+    needs:
+      - cargo-build
+      - cargo-fmt
+      - cargo-test-and-report
+      - cargo-clippy-and-report
+      - docker-build
+    if: github.repository == 'kristof-mattei/crack-hash' && github.event_name == 'pull_request'
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@f03ac48505955848960e80bbb68046aa35c7b9e7 # v2.4.1
+
+      - name: Download artifact
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        with:
+          name: ${{ env.DOCKER_IMAGE_ARTIFACT_NAME }}
+          path: ${{ env.DOCKER_IMAGE_OUTPUT_LOCATION }}
+
+      - name: Log into registry ${{ env.REGISTRY }}
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # tag=v2.1.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Load image from artifact
+        shell: bash
+        run: |
+          docker load --input ${{ env.DOCKER_IMAGE_TAR_LOCATION }}
+
+      - name: Push image with all tags
+        shell: bash
+        run: |
+          docker push ${REGISTRY,,}/${IMAGE_NAME,,} --all-tags
+
   all-done:
     name: All done
     # this is the job that should be marked as required on GitHub. It's the only one that'll reliably trigger
@@ -276,11 +479,13 @@ jobs:
       - cargo-fmt
       - cargo-clippy-and-report
       - cargo-test-and-report
-    if: ${{ always() }}
+      - docker-build
+      - docker-publish
+    if: always()
     steps:
       - name: Fail!
         shell: bash
-        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
         run: |
           echo "One / more upstream failed or was cancelled. Failing job..."
 

--- a/.github/workflows/cleanup-pr-images.yml
+++ b/.github/workflows/cleanup-pr-images.yml
@@ -1,0 +1,42 @@
+name: Cleanup PR closed, merged images
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+
+permissions:
+  contents: read
+  checks: write
+  pull-requests: write
+  issues: write
+  packages: write
+
+env:
+  CARGO_TERM_COLOR: always
+  # Use docker.io for Docker Hub if empty
+  REGISTRY: ghcr.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
+
+concurrency:
+  # each new commit to a PR runs this workflow
+  # so we need to avoid a long running older one from overwriting the "pr-<number>-latest"
+  group: "${{ github.workflow }} @ ${{ github.event.pull_request.head.label }}"
+  cancel-in-progress: true
+
+jobs:
+  cleanup:
+    name: Cleanup
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == false
+    steps:
+      - name: Void
+        shell: bash
+        run: |
+          echo "TODO put code here that cleans up images tagged pr-${{ github.event.number }}-latest"
+
+      # TODO clean up all tags related to pr-${{ github.event.number }}
+
+      # but we cannot delete labels from ghcr.io. # sad

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -1,21 +1,17 @@
-name: Lint Yaml
+name: Prettier
 
 on:
   workflow_dispatch:
   push:
     branches:
       - main
-    paths:
-      - "**/*.yml"
-      - "**/*.yaml"
   pull_request:
-    paths:
-      - "**/*.yml"
-      - "**/*.yaml"
+    branches:
+      - main
 
 jobs:
-  lint:
-    name: Lint
+  prettier:
+    name: Prettier
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo
@@ -33,7 +29,7 @@ jobs:
         run: |
           npm ci --ignore-scripts
 
-      - name: Run linter
+      - name: Run Prettier
         shell: bash
         run: |
-          npx --no-install prettier -c "**/*.{yml,yaml}"
+          npx --no-install prettier --check .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,60 @@
+name: Release
+
+env:
+  # Use docker.io for Docker Hub if empty
+  REGISTRY: ghcr.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
+
+concurrency:
+  group: "${{ github.workflow }}"
+  cancel-in-progress: true # only last step is important, which runs or doesn't
+
+on:
+  workflow_dispatch: # releasing is manual as we don't want to release every time
+    branches: [main]
+
+permissions:
+  contents: write # to write tags
+  packages: write # to write tags to Docker registry
+  issues: write
+  pull-requests: write
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Only on main
+        if: github.ref != 'refs/heads/main'
+        shell: bash
+        run: |
+          echo "Only to be executed on main"
+          exit 1
+
+      - name: Checkout
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        with:
+          token: ${{ secrets.TOKEN_TO_TRIGGER_SUBSEQUENT_WORKFLOWS }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
+        with:
+          node-version-file: ".nvmrc"
+          cache: "npm"
+          cache-dependency-path: "**/package-lock.json"
+
+      - name: Install dependencies
+        shell: bash
+        run: |
+          npm ci --ignore-scripts
+
+      - name: Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.TOKEN_TO_TRIGGER_SUBSEQUENT_WORKFLOWS }}
+        shell: bash
+        run: |
+          # TODO this release file produces a
+          # changelog
+          # we want to commit that and defer the release to THAT commit sha
+          npm run release

--- a/.github/workflows/semantic-tags-after-release.yml
+++ b/.github/workflows/semantic-tags-after-release.yml
@@ -1,0 +1,202 @@
+name: Update semantic tags on repo & image after release
+
+env:
+  # Use docker.io for Docker Hub if empty
+  REGISTRY: ghcr.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
+
+concurrency:
+  group: "${{ github.workflow }}"
+  cancel-in-progress: false # last one must win in case of multiple releases
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  move-git-tags:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
+        with:
+          node-version-file: ".nvmrc"
+          cache: "npm"
+          cache-dependency-path: "**/package-lock.json"
+
+      - name: Install dependencies
+        shell: bash
+        run: |
+          npm ci --ignore-scripts
+
+      - name: Split the incoming tag into major, minor and patch
+        uses: actions/github-script@98814c53be79b1d30f795b907e553d8679345975 # v6.4.0
+        env:
+          # because in the JS github variable ref_name isn't there
+          TAGNAME: ${{ github.ref_name }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const semver = require("semver");
+
+            // parse our version
+            let parsed = semver.parse(process.env.TAGNAME);
+
+            core.exportVariable("MAJOR", parsed.major);
+            core.exportVariable("MINOR", parsed.minor);
+            core.exportVariable("PATCH", parsed.patch);
+
+      - name: Move v${{ env.MAJOR }} and v${{ env.MAJOR }}.${{ env.MINOR }} tags
+        uses: actions/github-script@98814c53be79b1d30f795b907e553d8679345975 # v6.4.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { serializeError } = core.isDebug() ? require("serialize-error") : { serializeError: () => {} };
+
+            const tagsToMove = [
+                // already covered by semantic-release, it is what triggers this WF
+                // `v${process.env.MAJOR}.${process.env.MINOR}.${process.env.PATCH}`,
+                `v${process.env.MAJOR}.${process.env.MINOR}`,
+                // only do major if we're off v0, as v0 is the semver exception
+                ...(0 !== process.env.MAJOR ? [`v${process.env.MAJOR}`] : [])
+            ];
+
+            core.info(`Trying to move the following tags: ${tagsToMove.join(", ")} by deleting and re-creating.`);
+
+            async function move(tag) {
+                const ref = {
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    ref: `tags/${tag}`
+                };
+
+                try {
+                    await github.rest.git.deleteRef({
+                        ...ref,
+                    });
+
+                    core.info(`Deleted ${tag}.`);
+                } catch (e) {
+                    core.info(`The tag ${tag} doesn't exist yet, that's OK, it happens on new versions.`);
+                    core.debug(serializeError(e));
+                }
+
+                try {
+                    await github.rest.git.createRef({
+                        ...ref,
+                        // to delete a tag with deleteRef the format of the ref is tags/{tag}
+                        // to create a tag with createRef the format of the ref is /refs/tags/{tag}
+                        // # confused
+                        ref: `refs/${ref.ref}`,
+                        sha: context.sha
+                    });
+
+                    core.info(`Created ${tag} on ${context.sha}.`);
+
+                } catch (e) {
+                    core.setFailed(`Failed to create tag ${tag}.`);
+                    core.debug(serializeError(e));
+                }
+            }
+
+            await Promise.all(tagsToMove.map(move));
+
+            core.info("All done!");
+
+  retag-containers:
+    name: Retag the containers
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
+        with:
+          node-version-file: ".nvmrc"
+          cache: "npm"
+          cache-dependency-path: "**/package-lock.json"
+
+      - name: Install dependencies
+        shell: bash
+        run: |
+          npm ci --ignore-scripts
+
+      - name: Download crane tar, extract, and add folder to path.
+        uses: actions/github-script@98814c53be79b1d30f795b907e553d8679345975 # v6.4.0
+        with:
+          script: |
+            const tc = require("@actions/tool-cache");
+
+            const release = await github.rest.repos.getLatestRelease({
+                owner: "google",
+                repo: "go-containerregistry"
+            });
+
+            const asset = release.data.assets.find(asset => {
+                return asset["content_type"] === "application/gzip" && asset.name === "go-containerregistry_Linux_x86_64.tar.gz";
+            });
+
+            const urlToCraneTar = asset.browser_download_url
+
+            const craneTarPath = await tc.downloadTool(urlToCraneTar);
+            const craneExtractedFolder = await tc.extractTar(craneTarPath, null, ["--extract", "--gzip"]);
+
+            core.addPath(craneExtractedFolder);
+
+      - name: Log into registry ${{ env.REGISTRY }}
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # tag=v2.1.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set full image name
+        shell: bash
+        run: |
+
+          echo "FULL_IMAGE_NAME=${REGISTRY,,}/${IMAGE_NAME,,}" >> ${GITHUB_ENV}
+
+      - name: Find all tags for ${{ env.FULL_IMAGE_NAME }}
+        shell: bash
+        run: |
+
+          crane ls ${FULL_IMAGE_NAME} >> existing_tags
+
+          echo "These are the existing tags on ${FULL_IMAGE_NAME}:"
+          cat existing_tags
+
+      - name: Check if the incoming PR has a Docker container, which will be our old tag
+        shell: bash
+        run: |
+          old_tag=$(cat existing_tags | grep "^sha-${{ github.sha }}-.*\$") # .* is actual or retag
+
+          echo "OLD_TAG=${old_tag}" >> ${GITHUB_ENV}
+
+      - name: Set the new TAGs
+        id: meta
+        uses: docker/metadata-action@507c2f2dc502c992ad446e3d7a5dfbe311567a96 # v4.3.0
+        with:
+          images: "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}"
+          tags: |
+            type=raw,value=latest
+            type=semver,pattern=v{{version}}
+            type=semver,pattern=v{{major}}.{{minor}},enable=${{ !startsWith(github.ref, 'refs/tags/v0.0.') }}
+            type=semver,pattern=v{{major}},enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}
+
+      - name: Actually re-tag the container
+        shell: bash
+        run: |
+          echo "${{ steps.meta.outputs.tags }}" | while read new_tag
+          do
+            crane cp "${FULL_IMAGE_NAME}:${OLD_TAG}" ${new_tag}
+          done

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: returntocorp/semgrep@sha256:20337a678b9503a9ce572b4e04152a6e928627da0ec1f4c72f9551dd36d649d2
+      image: returntocorp/semgrep:1.13.0@sha256:20337a678b9503a9ce572b4e04152a6e928627da0ec1f4c72f9551dd36d649d2
 
     steps:
       - name: Check out repo

--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -1,0 +1,51 @@
+name: Test Release (do a dry run)
+
+env:
+  # Use docker.io for Docker Hub if empty
+  REGISTRY: ghcr.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
+
+on:
+  workflow_dispatch: # releasing is manual as we don't want to release every time
+
+permissions:
+  contents: write
+  issues: read
+  pull-requests: read
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Only on main
+        if: github.ref != 'refs/heads/main'
+        shell: bash
+        run: |
+          echo "Only to be executed on main"
+          exit 1
+
+      - name: Checkout
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
+        with:
+          node-version-file: ".nvmrc"
+          cache: "npm"
+          cache-dependency-path: "**/package-lock.json"
+
+      - name: Install dependencies
+        shell: bash
+        run: |
+          npm ci --ignore-scripts
+
+      - name: Release
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "::group::Release dry run output"
+          npm run release -- --dry-run
+          echo "::endgroup::"

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,7 @@
+.git
 .github/actions/
+profiling
+reports
+src   # rust-fmt
+tests # rust-fmt
+target

--- a/.prettierrc.yml
+++ b/.prettierrc.yml
@@ -4,3 +4,13 @@ overrides:
       - "**/*.{yml,yaml}"
     options:
       singleQuote: false
+  - files:
+      - "**/*.json"
+    options:
+      tabWidth: 4
+      trailingComma: all
+  - files:
+      - "package.json"
+      - "package-lock.json"
+    options:
+      tabWidth: 2

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,11 +9,7 @@
             "request": "launch",
             "name": "Debug executable 'crack-hash'",
             "cargo": {
-                "args": [
-                    "build",
-                    "--bin=crack-hash",
-                    "--package=crack-hash"
-                ],
+                "args": ["build", "--bin=crack-hash", "--package=crack-hash"],
                 "filter": {
                     "name": "crack-hash",
                     "kind": "bin"

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,88 +1,70 @@
 {
-	"version": "2.0.0",
-	"tasks": [
-		{
-			"type": "cargo",
-			"command": "check",
-			"problemMatcher": [
-				"$rustc"
-			],
-			"group": "build",
-			"label": "Rust: cargo check"
-		},
-		{
-			"type": "cargo",
-			"command": "clean",
-			"problemMatcher": [
-				"$rustc"
-			],
-			"group": "build",
-			"label": "Rust: cargo clean"
-		},
-		{
-			"type": "cargo",
-			"command": "build",
-			"args": [],
-			"problemMatcher": [
-				"$rustc"
-			],
-			"group": "build",
-			"label": "Rust: cargo build"
-		},
-		{
-			"type": "cargo",
-			"command": "fmt",
-			"args": [
-				"--all",
-			],
-			"problemMatcher": [
-				"$rustc"
-			],
-			"group": "build",
-			"label": "Rust: cargo fmt"
-		},
-		{
-			"type": "cargo",
-			"command": "clippy",
-			"args": [
-				"--workspace",
-				"--all-targets",
-				"--all-features",
-				"--",
-				"--deny",
-				"clippy::all",
-				"--deny",
-				"clippy::pedantic",
-				"--deny",
-				"clippy::cargo",
-			],
-			"problemMatcher": [
-				"$rustc"
-			],
-			"group": "build",
-			"label": "Rust: cargo clippy"
-		},
-		{
-			"type": "cargo",
-			"command": "test",
-			"args": [],
-			"problemMatcher": [
-				"$rustc"
-			],
-			"group": "test",
-			"label": "Rust: cargo test"
-		},
-		{
-			"type": "cargo",
-			"command": "test",
-			"args": [
-				"--release"
-			],
-			"problemMatcher": [
-				"$rustc"
-			],
-			"group": "test",
-			"label": "Rust: cargo test release"
-		},
-	]
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "type": "cargo",
+            "command": "check",
+            "problemMatcher": ["$rustc"],
+            "group": "build",
+            "label": "Rust: cargo check"
+        },
+        {
+            "type": "cargo",
+            "command": "clean",
+            "problemMatcher": ["$rustc"],
+            "group": "build",
+            "label": "Rust: cargo clean"
+        },
+        {
+            "type": "cargo",
+            "command": "build",
+            "args": [],
+            "problemMatcher": ["$rustc"],
+            "group": "build",
+            "label": "Rust: cargo build"
+        },
+        {
+            "type": "cargo",
+            "command": "fmt",
+            "args": ["--all"],
+            "problemMatcher": ["$rustc"],
+            "group": "build",
+            "label": "Rust: cargo fmt"
+        },
+        {
+            "type": "cargo",
+            "command": "clippy",
+            "args": [
+                "--workspace",
+                "--all-targets",
+                "--all-features",
+                "--",
+                "--deny",
+                "clippy::all",
+                "--deny",
+                "clippy::pedantic",
+                "--deny",
+                "clippy::cargo"
+            ],
+            "problemMatcher": ["$rustc"],
+            "group": "build",
+            "label": "Rust: cargo clippy"
+        },
+        {
+            "type": "cargo",
+            "command": "test",
+            "args": [],
+            "problemMatcher": ["$rustc"],
+            "group": "test",
+            "label": "Rust: cargo test"
+        },
+        {
+            "type": "cargo",
+            "command": "test",
+            "args": ["--release"],
+            "problemMatcher": ["$rustc"],
+            "group": "test",
+            "label": "Rust: cargo test release"
+        }
+    ]
 }

--- a/README.md
+++ b/README.md
@@ -1,14 +1,16 @@
 # Rust end-to-end application
+
 It's written in Rust!
 
 This is a framework for building Rust applications in combination with building Docker containers and never rebuilding code on release, instead we promote existing code.
 
 ## TODO and done
-* [x] Figure out how to deal with PRs pushing too many Docker containers<br />
+
+- [x] Figure out how to deal with PRs pushing too many Docker containers<br />
   > We only build containers on the tip of the PR, so even if you're pushing 10 commits, we'll only build one.
-* [ ] Remove old containers when the new one gets build for a PR?<br />
-  Or rely on a general weekly untagged cleanup?
-* [ ] Remove PR containers when PR closed<br />
+- [ ] Remove old containers when the new one gets build for a PR?<br />
+      Or rely on a general weekly untagged cleanup?
+- [ ] Remove PR containers when PR closed<br />
   > API currently unavailable
-* [x] How do we deal with older containers on `main`?<br />
+- [x] How do we deal with older containers on `main`?<br />
   > We move tags, so we'll need to wait for the API to clean up untagged versions

--- a/package-lock.json
+++ b/package-lock.json
@@ -5379,9 +5379,9 @@
       }
     },
     "node_modules/readable-stream": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "dev": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
@@ -5666,9 +5666,9 @@
       }
     },
     "node_modules/semantic-release/node_modules/lru-cache": {
-      "version": "7.16.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.16.1.tgz",
-      "integrity": "sha512-9kkuMZHnLH/8qXARvYSjNvq8S1GYFFzynQTAfKeaJ0sIrR3PUPuu37Z+EiIANiZBvpfTf2B5y8ecDLSMWlLv+w==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.17.0.tgz",
+      "integrity": "sha512-zSxlVVwOabhVyTi6E8gYv2cr6bXK+8ifYz5/uyJb9feXX6NACVDwY4p5Ut3WC3Ivo/QhpARHU3iujx2xGAYHbQ==",
       "dev": true,
       "engines": {
         "node": ">=12"
@@ -5960,9 +5960,9 @@
       }
     },
     "node_modules/split2/node_modules/readable-stream": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.1.tgz",
+      "integrity": "sha512-+rQmrWMYGA90yenhTYsLWAsLsqVC8osOw6PKE1HDYiO0gdPeKe/xDHNzIAIn4C91YQ6oenEhfYqqc1883qHbjQ==",
       "dev": true,
       "dependencies": {
         "inherits": "^2.0.3",
@@ -6195,9 +6195,9 @@
       }
     },
     "node_modules/through2/node_modules/readable-stream": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.1.tgz",
+      "integrity": "sha512-+rQmrWMYGA90yenhTYsLWAsLsqVC8osOw6PKE1HDYiO0gdPeKe/xDHNzIAIn4C91YQ6oenEhfYqqc1883qHbjQ==",
       "dev": true,
       "dependencies": {
         "inherits": "^2.0.3",
@@ -6455,9 +6455,9 @@
       "dev": true
     },
     "node_modules/yargs": {
-      "version": "17.7.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.0.tgz",
-      "integrity": "sha512-dwqOPg5trmrre9+v8SUo2q/hAwyKoVfu8OC1xPHKJGNdxAvPl4sKxL4vBnh3bQz/ZvvGAFeA5H3ou2kcOY8sQQ==",
+      "version": "17.7.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.1.tgz",
+      "integrity": "sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==",
       "dev": true,
       "dependencies": {
         "cliui": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "It's written in Rust!",
   "main": "src/main.rs",
   "scripts": {
-    "prettier": "prettier -w \"**/*.{yml,yaml}\"",
+    "prettier": "prettier --write .",
     "release": "semantic-release"
   },
   "engines": {


### PR DESCRIPTION
- fix: lock down with version and digest
- chore(deps): update returntocorp/semgrep:1.2.1 docker digest to 4569a84
- chore(deps): update returntocorp/semgrep docker tag to v1.12.1
- chore(deps): lock file maintenance
- chore(deps): update actions/cache action to v3.2.6
- chore: ensure we take the longest tag, v1.0.0 instead of v1
- chore(deps): update node.js to >=v18.14.2
- chore: updated devcontainer config
- fix: more formatting enforcement
- chore(deps): pin mcr.microsoft.com/devcontainers/rust docker tag to 7eb80e1
- fix: allow for building / not building docker container
- chore(deps): update npm to >=9.5.1
- chore(deps): update returntocorp/semgrep docker tag to v1.13.0
